### PR TITLE
Introduce syntect as code syntax highlighting backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crossterm = "0.28"
 tui-textarea = "0.7"
 image = "0.25"
 ratatui-image = "3.0"
+syntect = "5.2"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 dirs = "5.0"


### PR DESCRIPTION
Implements #3, using [syntect](https://github.com/trishume/syntect) as simple way to introduce a plethora of syntax highlighting options in code blocks. There is a place for further expansion, if one wanted to put in the extra work:
- [ ] Make the syntect themes sync with main theme/be configurable alongside it
- [ ] Load custom language definitions

Some technicals:
Uses "base16-ocean.dark" as the default (and the only for now) syntax highlighting theme
We have to manually convert the syntect output back into ratatui's styling, which is not perfect, but is at least safer than directly using the escape sequences that syntect could provide.
If the language string is not recognized properly, it falls back to the exact same style as before the changes