### PR TITLE
fix: add freebsd target for external link open

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -3499,7 +3499,7 @@ impl App {
 
         #[cfg(target_os = "macos")]
         let _ = Command::new("open").arg(url).spawn();
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
         let _ = Command::new("xdg-open").arg(url).spawn();
         #[cfg(target_os = "windows")]
         let _ = Command::new("cmd").args(["/c", "start", "", url]).spawn();
@@ -4366,7 +4366,7 @@ impl App {
 
         #[cfg(target_os = "macos")]
         let _ = Command::new("open").arg(&open_path).spawn();
-        #[cfg(any(target_os = "linux", target_os = "android"))]
+        #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
         let _ = Command::new("xdg-open").arg(&open_path).spawn();
         #[cfg(target_os = "windows")]
         let _ = Command::new("cmd").args(["/c", "start", "", &open_path]).spawn();

--- a/src/event/handler.rs
+++ b/src/event/handler.rs
@@ -362,7 +362,7 @@ fn handle_mouse_event(app: &mut App, mouse: crossterm::event::MouseEvent) {
                             if let Some(open_path) = open_path {
                                 #[cfg(target_os = "macos")]
                                 let _ = std::process::Command::new("open").arg(&open_path).spawn();
-                                #[cfg(any(target_os = "linux", target_os = "android"))]
+                                #[cfg(any(target_os = "android", target_os = "freebsd", target_os = "linux"))]
                                 let _ = std::process::Command::new("xdg-open").arg(&open_path).spawn();
                                 #[cfg(target_os = "windows")]
                                 let _ = std::process::Command::new("cmd").args(["/c", "start", "", &open_path]).spawn();


### PR DESCRIPTION
Use alphabetical order for the target_os values.
